### PR TITLE
Lock local setup to CPU-only PyTorch and improve setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+nohup.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Locked local setup to CPU-only PyTorch with `torch==2.13.0+cpu` and configured `scripts/pysetup.sh` to use the PyTorch CPU wheel index.
+- Updated local setup docs to recommend the helper install script and CPU-only dependency install path.
+- Added `nohup.out` to `.gitignore` to keep transient logs out of the repository.

--- a/Local_Setup_No_Docker.md
+++ b/Local_Setup_No_Docker.md
@@ -56,21 +56,21 @@ where python    # Windows
 
 If the repo includes helper scripts (e.g., `scripts/pysetup.sh`), prefer using them. Otherwise install from requirements files.
 
-### Option A — Use setup script (if present)
+### Option A — Use setup script (recommended)
 ```bash
 # macOS/Linux or Windows via Git Bash/WSL
 bash -i scripts/pysetup.sh py_env
 ```
 
+This script upgrades `pip` and installs dependencies using the CPU PyTorch wheel index, which avoids hangs on machines without CUDA.
+
 ### Option B — Manual install from requirements
 ```bash
 pip install --upgrade pip wheel
-# If a single file exists:
-# pip install -r requirements.txt
-# If multiple pinned files exist:
-# pip install -r requirements/base.txt
-# pip install -r requirements/dev.txt
+pip install --extra-index-url https://download.pytorch.org/whl/cpu -r requirements/requirements.txt
 ```
+
+If the repository later adds separate `requirements/base.txt` or `requirements/dev.txt` files, install them with the same `--extra-index-url` flag.
 
 ---
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,7 @@
+# Use the PyTorch CPU wheels for local environments without CUDA.
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.13.0+cpu
+
 # ── LangChain & Ollama integration ───────────────────────────────────────
 langchain==0.3.26
 langchain-community==0.3.26

--- a/scripts/pysetup.sh
+++ b/scripts/pysetup.sh
@@ -8,10 +8,12 @@ python3 -m venv ./$PYTHON_ENV \
 
 source ./$PYTHON_ENV/bin/activate
 
+pip3 install --upgrade pip wheel
+
 if [ -f "./requirements.txt" ]; then
-  pip3 install -r "./requirements.txt"
+  pip3 install --extra-index-url https://download.pytorch.org/whl/cpu -r "./requirements.txt"
 elif [ -f "./requirements/requirements.txt" ]; then
-  pip3 install -r "./requirements/requirements.txt"
+  pip3 install --extra-index-url https://download.pytorch.org/whl/cpu -r "./requirements/requirements.txt"
 else
-  pip3 install -r "/workspaces/ai-aip/requirements/requirements.txt"
+  pip3 install --extra-index-url https://download.pytorch.org/whl/cpu -r "/workspaces/ai-aip/requirements/requirements.txt"
 fi


### PR DESCRIPTION
This pull request fixes the local setup for users without CUDA by locking the repo to CPU-only PyTorch and updating the install flow to use the PyTorch CPU wheel index. It also improves local setup documentation, adds a changelog entry, and ignores transient nohup logs to keep the repository clean.